### PR TITLE
image bgr to rgb

### DIFF
--- a/server.py
+++ b/server.py
@@ -111,7 +111,7 @@ async def detect_via_api(request: Request,
 	if model_dict[model_name] is None:
 		model_dict[model_name] = torch.hub.load('ultralytics/yolov5', model_name, pretrained=True)
 
-	img_batch = [cv2.imdecode(np.fromstring(await file.read(), np.uint8), cv2.IMREAD_COLOR)
+	img_batch = [cv2.imdecode(np.fromstring(await file.read(), np.uint8), cv2.IMREAD_COLOR)[:,:,::-1] # BGR TO RGB
 					for file in file_list]
 	
 	if download_image:
@@ -120,6 +120,7 @@ async def detect_via_api(request: Request,
 		json_results = results_to_json(results,model_dict[model_name])
 
 		for idx, (img, bbox_list) in enumerate(zip(img_batch, json_results)):
+			img = img[:,:,::-1] # RGB TO BGR
 			for bbox in bbox_list:
 				label = f'{bbox["class_name"]} {bbox["confidence"]:.2f}'
 				plot_one_box(bbox['bbox'], img, label=label, 


### PR DESCRIPTION
Hello, Thanks for this open source, I can process my project.
I had some problem with model inference. And I found what problem is.
![image](https://user-images.githubusercontent.com/63527907/146198575-40744b4f-4909-4c49-bc7c-c0291380c53c.png)

Here is the code
```
import numpy as np
import torch
from PIL import Image

model = torch.hub.load('ultralytics/yolov5', 'yolov5s')
image = Image.open('data/images/bus.jpg')
result = model(image)
print(result.pandas().xyxy[0])
image.show()

import cv2
path = 'data/images/bus.jpg'
with open(path, 'rb') as f:
    data = f.read()
encoded_img = np.fromstring(data, dtype = np.uint8)
img = cv2.imdecode(encoded_img, cv2.IMREAD_COLOR)
result = model(img)
print(result.pandas().xyxy[0])
img=Image.fromarray(img)
img.show()
```
Like these pictures, though same images, results of model inference are different.
If I use `cv2.imdecode()`, image changed to bgr. So I have to change bgr to rgb. Thank you!
